### PR TITLE
Add WD14 AI tags tab with confidence filtering

### DIFF
--- a/frontend/src/components/MediaContentTabs.tsx
+++ b/frontend/src/components/MediaContentTabs.tsx
@@ -12,6 +12,8 @@ import TagIcon from "@mui/icons-material/Tag";
 import PeopleIcon from "@mui/icons-material/People";
 import CollectionsIcon from "@mui/icons-material/Collections";
 import DataObjectIcon from "@mui/icons-material/DataObject";
+import PsychologyIcon from "@mui/icons-material/Psychology";
+import { Wd14Tags } from "./Wd14Tags";
 interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
@@ -50,12 +52,14 @@ export function MediaContentTabs(props: MediaContentTabsProps) {
       sx={{ minHeight: "64px" }} // Taller tabs for a better look
     />
   );
+  const hasPeopleTab = config.ENABLE_PEOPLE;
   const tabIndices = {
     similar: 0,
-    people: config.ENABLE_PEOPLE ? 1 : -1, // -1 if not rendered
-    tags: config.ENABLE_PEOPLE ? 2 : 1,
-    exif: config.ENABLE_PEOPLE ? 3 : 2,
-  };
+    people: hasPeopleTab ? 1 : -1, // -1 if not rendered
+    tags: hasPeopleTab ? 2 : 1,
+    aiTags: hasPeopleTab ? 3 : 2,
+    exif: hasPeopleTab ? 4 : 3,
+  } as const;
 
   return (
     <Box sx={{ width: "100%", mt: 4 }}>
@@ -72,6 +76,7 @@ export function MediaContentTabs(props: MediaContentTabsProps) {
             persons &&
             renderTab(`People (${persons.length})`, <PeopleIcon />)}
           {renderTab("Tags", <TagIcon />)}
+          {renderTab("AI Tags (WD14)", <PsychologyIcon />)}
           {renderTab("Exif Data", <DataObjectIcon />)}
         </Tabs>
       </Box>
@@ -98,6 +103,9 @@ export function MediaContentTabs(props: MediaContentTabsProps) {
               onTagAdded={onTagAdded}
               onUpdate={onTagUpdate}
             />
+          </TabPanel>
+          <TabPanel value={tabValue} index={tabIndices.aiTags}>
+            <Wd14Tags media={media} />
           </TabPanel>
 
           <TabPanel value={tabValue} index={tabIndices.exif}>

--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -7,6 +7,7 @@ import {
   removeTagFromMedia,
   removeTagFromPerson,
 } from "../services/tagActions";
+import { isWd14TagName } from "../utils/aiTags";
 
 export interface TagsProps {
   media?: Media;
@@ -17,6 +18,14 @@ export interface TagsProps {
 export function Tags({ media, person, onUpdate }: Readonly<TagsProps>) {
   const owner = media || person;
   if (!owner) {
+    return null;
+  }
+
+  const displayTags = (owner.tags ?? []).filter(
+    (tag) => !isWd14TagName(tag.name),
+  );
+
+  if (displayTags.length === 0) {
     return null;
   }
 
@@ -45,7 +54,7 @@ export function Tags({ media, person, onUpdate }: Readonly<TagsProps>) {
         Tags
       </Typography>
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-        {(owner.tags ?? []).map((tag) => (
+        {displayTags.map((tag) => (
           <Chip
             key={tag.id}
             label={tag.name}

--- a/frontend/src/components/TagsSection.tsx
+++ b/frontend/src/components/TagsSection.tsx
@@ -4,6 +4,7 @@ import { Media, Person, Tag } from "../types";
 import config from "../config";
 import TagAdder from "./TagAdder";
 import { Tags } from "./Tags";
+import { isWd14TagName } from "../utils/aiTags";
 
 interface TagsSectionProps {
   media?: Media;
@@ -21,6 +22,7 @@ export function TagsSection({
   const owner = media || person;
   const ownerType = media ? "media" : "person";
   const tags = owner.tags ?? [];
+  const manualTags = tags.filter((tag) => !isWd14TagName(tag.name));
   const ownerId = owner.id;
   return (
     <Box mt={4}>
@@ -32,13 +34,13 @@ export function TagsSection({
           <TagAdder
             ownerType={ownerType}
             ownerId={ownerId}
-            existingTags={tags ?? []}
+            existingTags={manualTags}
             onTagAdded={onTagAdded}
           />
         </Box>
       )}
 
-      {tags && tags.length > 0 && (
+      {manualTags.length > 0 && (
         <Tags media={media} person={person} onUpdate={onUpdate} />
       )}
     </Box>

--- a/frontend/src/components/Wd14Tags.tsx
+++ b/frontend/src/components/Wd14Tags.tsx
@@ -1,0 +1,89 @@
+import { useMemo, useState } from "react";
+import { Box, Chip, Slider, Stack, Typography } from "@mui/material";
+
+import { Media } from "../types";
+import { parseWd14Tags } from "../utils/aiTags";
+
+interface Wd14TagsProps {
+  media: Media;
+}
+
+export function Wd14Tags({ media }: Readonly<Wd14TagsProps>) {
+  const [minConfidence, setMinConfidence] = useState<number>(0);
+
+  const parsedTags = useMemo(
+    () =>
+      parseWd14Tags(media.tags).sort((a, b) => b.score - a.score),
+    [media.tags],
+  );
+
+  const filteredTags = useMemo(
+    () => parsedTags.filter((tag) => tag.score * 100 >= minConfidence),
+    [parsedTags, minConfidence],
+  );
+
+  const handleSliderChange = (_: Event, value: number | number[]) => {
+    const nextValue = Array.isArray(value) ? value[0] : value;
+    setMinConfidence(nextValue);
+  };
+
+  if (parsedTags.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No AI-generated tags were found for this media item.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ maxWidth: 320, mb: 3 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Minimum confidence: {minConfidence}%
+        </Typography>
+        <Slider
+          aria-label="Minimum confidence"
+          value={minConfidence}
+          valueLabelDisplay="auto"
+          onChange={handleSliderChange}
+          min={0}
+          max={100}
+        />
+      </Box>
+
+      {filteredTags.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No tags match the current confidence threshold.
+        </Typography>
+      ) : (
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {filteredTags.map((tag) => {
+            const percent = Math.round(tag.score * 100);
+            return (
+              <Chip
+                key={tag.tag.id}
+                label={
+                  <Box component="span" sx={{ display: "flex", alignItems: "baseline", gap: 0.5 }}>
+                    <Box component="span" sx={{ fontWeight: 500 }}>
+                      {tag.label}
+                    </Box>
+                    <Box component="span" sx={{ color: "text.secondary", fontSize: "0.75rem" }}>
+                      {percent}%
+                    </Box>
+                  </Box>
+                }
+                variant="outlined"
+                sx={{
+                  "& .MuiChip-label": {
+                    display: "flex",
+                    alignItems: "center",
+                  },
+                }}
+              />
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/utils/aiTags.ts
+++ b/frontend/src/utils/aiTags.ts
@@ -1,0 +1,49 @@
+import { Tag } from "../types";
+
+export const WD14_TAG_PREFIX = "wd14:";
+
+export interface Wd14Tag {
+  label: string;
+  score: number;
+  tag: Tag;
+}
+
+export function isWd14TagName(tagName: string): boolean {
+  return tagName.startsWith(WD14_TAG_PREFIX);
+}
+
+export function parseWd14TagName(tagName: string): Pick<Wd14Tag, "label" | "score"> | null {
+  if (!isWd14TagName(tagName)) {
+    return null;
+  }
+
+  const remainder = tagName.slice(WD14_TAG_PREFIX.length);
+  const [rawLabel, rawScore] = remainder.split("|");
+  if (!rawLabel || !rawScore) {
+    return null;
+  }
+
+  const score = Number(rawScore);
+  if (Number.isNaN(score)) {
+    return null;
+  }
+
+  const label = rawLabel.replace(/_/g, " ").trim();
+  return { label, score };
+}
+
+export function parseWd14Tags(tags: Tag[]): Wd14Tag[] {
+  return tags
+    .map((tag) => {
+      const parsed = parseWd14TagName(tag.name);
+      if (!parsed) {
+        return null;
+      }
+
+      return {
+        ...parsed,
+        tag,
+      } as Wd14Tag;
+    })
+    .filter((parsedTag): parsedTag is Wd14Tag => parsedTag !== null);
+}


### PR DESCRIPTION
## Summary
- add a reusable WD14 tag parsing utility and dedicated AI tags component with a confidence slider
- extend the media detail tabs with a new "AI Tags (WD14)" view powered by the new component
- hide WD14-prefixed tags from the manual tags section to avoid duplicate presentation

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ecb733d1648325bdf33fbb556ae5ad