### PR TITLE
Refine WD14 tagging flow and UI parsing

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -354,7 +354,10 @@ class Wd14TaggingSettings(BaseModel):
         default_factory=lambda: Wd14CategorySettings(threshold=0.35)
     )
     character: Wd14CategorySettings = Field(
-        default_factory=lambda: Wd14CategorySettings(threshold=0.5)
+        default_factory=lambda: Wd14CategorySettings(threshold=0.75)
+    )
+    copyright: Wd14CategorySettings = Field(
+        default_factory=lambda: Wd14CategorySettings(threshold=0.75)
     )
     rating: Wd14CategorySettings = Field(
         default_factory=lambda: Wd14CategorySettings(threshold=0.5)

--- a/app/processors/base.py
+++ b/app/processors/base.py
@@ -33,6 +33,10 @@ class MediaProcessor(ABC):
         Should commit its own changes (e.g. write to its own tables).
         """
 
+    def finalize(self, session: Session) -> None:
+        """Optional hook invoked after all media have been processed."""
+        return
+
     def get_results(self, media_id: int, session: Session):
         """
         Return something JSON‑serializable about this media.

--- a/app/processors/wd14_tagger.py
+++ b/app/processors/wd14_tagger.py
@@ -43,6 +43,7 @@ class WD14Tagger(MediaProcessor):
         self._score_sum: float = 0.0
         self._score_count: int = 0
         self._min_dimension: int = 64
+        self._summary_logged: bool = False
 
     def load_model(self):
         cfg = getattr(settings.tagging, "wd14", None)
@@ -95,10 +96,12 @@ class WD14Tagger(MediaProcessor):
         self._category_thresholds = {
             "general": (cfg.general.enabled, float(cfg.general.threshold)),
             "character": (cfg.character.enabled, float(cfg.character.threshold)),
+            "copyright": (cfg.copyright.enabled, float(cfg.copyright.threshold)),
             "rating": (cfg.rating.enabled, float(cfg.rating.threshold)),
         }
         self._batch_size = max(1, int(cfg.batch_size or 1))
         self._max_tags = max(0, int(cfg.max_tags or 0))
+        self._summary_logged = False
         self.active = True
         logger.info(
             "WD14Tagger ready (model=%s, labels=%s, batch=%s, max_tags=%s)",
@@ -109,21 +112,7 @@ class WD14Tagger(MediaProcessor):
         )
 
     def unload(self):
-        if self._processed_items:
-            avg_tags = (
-                self._total_tags_assigned / self._processed_items
-                if self._processed_items
-                else 0.0
-            )
-            mean_score = (
-                self._score_sum / self._score_count if self._score_count else 0.0
-            )
-            logger.info(
-                "WD14Tagger summary: %s media, avg tags %.2f, mean score %.3f",
-                self._processed_items,
-                avg_tags,
-                mean_score,
-            )
+        self._log_summary()
         self._ort_session = None
         self._ort_input = None
         self._pending.clear()
@@ -135,6 +124,7 @@ class WD14Tagger(MediaProcessor):
         self._total_tags_assigned = 0
         self._score_sum = 0.0
         self._score_count = 0
+        self._summary_logged = False
 
     def process(
         self,
@@ -180,11 +170,16 @@ class WD14Tagger(MediaProcessor):
 
         self._pending.append((media, tensor))
         self._flush_queue(session, force=len(self._pending) >= self._batch_size)
-        # Always flush to avoid leaving items pending when batch < configured size
-        self._flush_queue(session, force=True)
         return True
 
     # ----- Internal helpers -------------------------------------------------
+
+    def finalize(self, session: Session) -> None:
+        if not self.active or not self._ort_session:
+            self._log_summary()
+            return
+        self._flush_queue(session, force=True)
+        self._log_summary()
 
     def _flush_queue(self, session: Session, force: bool) -> None:
         if not self._pending:
@@ -312,6 +307,7 @@ class WD14Tagger(MediaProcessor):
             return None
         arr = arr / 255.0
         arr = np.transpose(arr, (2, 0, 1))
+        arr = (arr - 0.5) / 0.5
         return arr[np.newaxis, ...]
 
     def _load_tag_definitions(self, path: Path) -> list[_TagDefinition]:
@@ -337,8 +333,8 @@ class WD14Tagger(MediaProcessor):
         mapping = {
             "0": "general",
             "1": "general",
-            "2": "general",
-            "3": "general",
+            "2": "copyright",
+            "3": "character",
             "4": "character",
             "5": "general",
             "6": "general",
@@ -347,9 +343,29 @@ class WD14Tagger(MediaProcessor):
             "9": "rating",
             "general": "general",
             "character": "character",
+            "copyright": "copyright",
             "rating": "rating",
         }
         return mapping.get(value, value or "general")
+
+    def _log_summary(self) -> None:
+        if self._summary_logged or not self._processed_items:
+            return
+        avg_tags = (
+            self._total_tags_assigned / self._processed_items
+            if self._processed_items
+            else 0.0
+        )
+        mean_score = (
+            self._score_sum / self._score_count if self._score_count else 0.0
+        )
+        logger.info(
+            "WD14Tagger summary: %s media, avg tags %.2f, mean score %.3f",
+            self._processed_items,
+            avg_tags,
+            mean_score,
+        )
+        self._summary_logged = True
 
     def _resolve_model_path(self, configured: str | None) -> Path | None:
         candidates: list[Path] = []

--- a/app/tasks/media_processing.py
+++ b/app/tasks/media_processing.py
@@ -325,6 +325,13 @@ def run_media_processing(task_id: str) -> None:
                     break
 
             for proc in processors:
+                if getattr(proc, "active", False):
+                    try:
+                        proc.finalize(session)
+                    except Exception:
+                        logger.exception(
+                            "Processor '%s' finalize hook failed", proc.name
+                        )
                 try:
                     proc.unload()
                 except Exception:

--- a/frontend/src/utils/aiTags.ts
+++ b/frontend/src/utils/aiTags.ts
@@ -28,7 +28,7 @@ export function parseWd14TagName(tagName: string): Pick<Wd14Tag, "label" | "scor
     return null;
   }
 
-  const label = rawLabel.replace(/_/g, " ").trim();
+  const label = rawLabel.trim();
   return { label, score };
 }
 


### PR DESCRIPTION
## Summary
- add a finalize hook to media processors so WD14 can flush batched predictions before shutdown
- extend the WD14 tagger with configurable copyright thresholds, true batching, and summary logging
- adjust the AI tag parser to keep original labels for display

## Testing
- uv run python -m compileall app/processors/base.py app/processors/wd14_tagger.py app/tasks/media_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68ecb0d1603c8325bfb8b51216d10a2d