### PR TITLE
Prevent WD14 pending items from requeuing

### DIFF
--- a/app/processors/wd14_tagger.py
+++ b/app/processors/wd14_tagger.py
@@ -168,6 +168,9 @@ class WD14Tagger(MediaProcessor):
             session.add(media)
             return True
 
+        media.ran_auto_tagging = True
+        session.add(media)
+
         self._pending.append((media, tensor))
         self._flush_queue(session, force=len(self._pending) >= self._batch_size)
         return True
@@ -193,6 +196,9 @@ class WD14Tagger(MediaProcessor):
             outputs = self._ort_session.run(None, {self._ort_input: batch})
         except Exception:
             logger.exception("WD14Tagger: inference failed; clearing pending queue")
+            for media_obj in medias:
+                media_obj.ran_auto_tagging = False
+                session.add(media_obj)
             self._pending.clear()
             return
 
@@ -203,6 +209,9 @@ class WD14Tagger(MediaProcessor):
                 scores.shape[0],
                 len(medias),
             )
+            for media_obj in medias:
+                media_obj.ran_auto_tagging = False
+                session.add(media_obj)
             self._pending.clear()
             return
 


### PR DESCRIPTION
## Summary
- mark media as auto-tagged when queued for WD14 inference so pending items are not repeatedly re-selected
- reset the auto-tagging flag if batch inference fails to ensure items can be retried

## Testing
- uv run python -m compileall app/processors/wd14_tagger.py

------
https://chatgpt.com/codex/tasks/task_e_68ecbd66aa0c8325a57671f6a16053b9