### PR TITLE
Fix WD14 tag naming to avoid embedding scores

### DIFF
--- a/app/processors/wd14_tagger.py
+++ b/app/processors/wd14_tagger.py
@@ -241,12 +241,12 @@ class WD14Tagger(MediaProcessor):
             scored_tags = scored_tags[: self._max_tags]
 
         formatted = [
-            (f"wd14:{name}|{score:.2f}", score)
-            for name, score, _ in scored_tags
+            (f"wd14:{name}", score, category)
+            for name, score, category in scored_tags
         ]
-        scores_only = [score for _, score in formatted]
+        scores_only = [score for _, score, _ in formatted]
 
-        for tag_name, score in formatted:
+        for tag_name, score, _ in formatted:
             tag = get_or_create_tag(tag_name, session)
             attach_tag_to_media(media.id, tag.id, session, score=score)
 


### PR DESCRIPTION
## Summary
- update the WD14 tagger to generate stable tag names without embedding the score
- continue storing the confidence score in the media-tag link while keeping tag names deduplicated

## Testing
- python -m compileall app/processors/wd14_tagger.py

------
https://chatgpt.com/codex/tasks/task_e_68ecbd69816c83259eb99c77270c8064